### PR TITLE
Remove DM_ prefix from FS event type constants.

### DIFF
--- a/etc/peripetyd.conf
+++ b/etc/peripetyd.conf
@@ -14,4 +14,4 @@ regex = '''(?x)
 '''
 # `kdev` naming capture group is mandatory.
 sub_system = "ext4"
-event_type = "DM_FS_MOUNTED"
+event_type = "FS_MOUNTED"

--- a/examples/fs/ext4_mount_lv_mpath_scsi.json
+++ b/examples/fs/ext4_mount_lv_mpath_scsi.json
@@ -4,7 +4,7 @@
   "sub_system": "FsExt4",
   "timestamp": 1526476997012691,
   "event_id": "",
-  "event_type": "DM_FS_MOUNTED",
+  "event_type": "FS_MOUNTED",
   "dev_wwid": "47841ee5-047d-4f73-8951-5a3d7a4c770e",
   "dev_path": "/dev/mapper/vg-lv",
   "owners_wwids": [

--- a/src/peripetyd/src/buildin_regex.rs
+++ b/src/peripetyd/src/buildin_regex.rs
@@ -103,7 +103,7 @@ pub const BUILD_IN_REGEX_CONFS: &[RegexConfStr] = &[
                 mounted\ filesystem\s
                 ",
         sub_system: "ext4",
-        event_type: "DM_FS_MOUNTED",
+        event_type: "FS_MOUNTED",
     },
     RegexConfStr {
         starts_with: Some("XFS "),
@@ -112,7 +112,7 @@ pub const BUILD_IN_REGEX_CONFS: &[RegexConfStr] = &[
                 \((?P<kdev>[^\s\)]+)\):\s
                 Ending\ clean\ mount",
         sub_system: "xfs",
-        event_type: "DM_FS_MOUNTED",
+        event_type: "FS_MOUNTED",
     },
     RegexConfStr {
         starts_with: Some("XFS "),
@@ -121,7 +121,7 @@ pub const BUILD_IN_REGEX_CONFS: &[RegexConfStr] = &[
                 \((?P<kdev>[^\s\)]+)\):\s
                 Unmounting\ Filesystem$",
         sub_system: "xfs",
-        event_type: "DM_FS_UNMOUNTED",
+        event_type: "FS_UNMOUNTED",
     },
     RegexConfStr {
         starts_with: Some("XFS "),
@@ -130,7 +130,7 @@ pub const BUILD_IN_REGEX_CONFS: &[RegexConfStr] = &[
                 \((?P<kdev>[^\s\)]+)\):\s
                 writeback\ error\ on\ sector",
         sub_system: "xfs",
-        event_type: "DM_FS_IO_ERROR",
+        event_type: "FS_IO_ERROR",
     },
     RegexConfStr {
         starts_with: Some("EXT4-fs "),
@@ -141,7 +141,7 @@ pub const BUILD_IN_REGEX_CONFS: &[RegexConfStr] = &[
                 ext4_end_bio:[0-9]+:\ I/O\ error
                 ",
         sub_system: "ext4",
-        event_type: "DM_FS_IO_ERROR",
+        event_type: "FS_IO_ERROR",
     },
     RegexConfStr {
         starts_with: Some("JBD2: "),
@@ -151,6 +151,6 @@ pub const BUILD_IN_REGEX_CONFS: &[RegexConfStr] = &[
                 (?P<kdev>[^\s]+)-[0-9]+$
                 ",
         sub_system: "ext4",
-        event_type: "DM_FS_IO_ERROR",
+        event_type: "FS_IO_ERROR",
     },
 ];


### PR DESCRIPTION
Just cleaning up what I think are copy/paste errors.